### PR TITLE
printrun: unstable-2023-01-29 -> unstable-2023-01-31

### DIFF
--- a/printrun/default.nix
+++ b/printrun/default.nix
@@ -2,13 +2,13 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "printrun";
-  version = "unstable-2023-01-29";
+  version = "unstable-2023-01-31";
 
   src = fetchFromGitHub {
     owner = "kliment";
     repo = "Printrun";
-    rev = "2e2adc63740b39fc5e3978f3e6d88ca7a4c39f2a";
-    hash = "sha256-fZbAk9bPN4vv4SAEU53uEl1RLr2GFpcB2XrTKobtI8k=";
+    rev = "0c296bab07a4e6a11470082156cf078f745a54a2";
+    hash = "sha256-gZDuPoVCyQ5MiSGvtH9+opAjuepEwHBhcJrjQbLsVOQ=";
   };
 
   propagatedBuildInputs = with python3Packages; [


### PR DESCRIPTION
Automated update by update.py (method: git-commits).