### PR TITLE
nextpnr-unstable: unstable-2023-02-23 -> unstable-2023-02-22

### DIFF
--- a/nextpnr-unstable/default.nix
+++ b/nextpnr-unstable/default.nix
@@ -1,13 +1,13 @@
 { nextpnrWithGui, callPackage, fetchFromGitHub }:
 
 nextpnrWithGui.overrideAttrs (final: prev: {
-  version = "unstable-2023-02-23";
+  version = "unstable-2023-02-22";
 
   src = fetchFromGitHub {
     owner = "YosysHQ";
     repo = "nextpnr";
-    rev = "ebbaf8c08dbde251aa4f2809f296b20a7a2266a8";
-    hash = "sha256-GxBLgAJ8i0AvuRRJPVvSqpNnDdnKf8Z6BNjkQBzuVW0=";
+    rev = "14050f991bc2e4ce2c6e7f431fe2acd4f0cf2a70";
+    hash = "sha256-KE9v8i4xJoU+09rJgjq5c/KrURy/sEtFe3UkqwKEBjo=";
   };
 
   passthru = (prev.passthru or { }) // { autoUpdate = "git-commits"; };


### PR DESCRIPTION
Automated update by update.py (method: git-commits).