### PR TITLE
nextpnr-unstable: unstable-2023-03-22 -> unstable-2023-04-05

### DIFF
--- a/nextpnr-unstable/default.nix
+++ b/nextpnr-unstable/default.nix
@@ -1,13 +1,13 @@
 { nextpnrWithGui, callPackage, fetchFromGitHub }:
 
 nextpnrWithGui.overrideAttrs (final: prev: {
-  version = "unstable-2023-03-22";
+  version = "unstable-2023-04-05";
 
   src = fetchFromGitHub {
     owner = "YosysHQ";
     repo = "nextpnr";
-    rev = "b36e8a3013ac70a9fbe71d2163f660dafe3b8b2f";
-    hash = "sha256-8U6emILwRFoxD5BuZL6SrtoJmZLZ3Lzi+PFvvWvmiew=";
+    rev = "9bcefe46a89a1fb55ab86f2e0a3319baf1b92807";
+    hash = "sha256-gMCAYLZ61zkSSShAzbk8RVSXAF6Kfzptu7VT4Er9YZc=";
   };
 
   passthru = (prev.passthru or { }) // { autoUpdate = "git-commits"; };


### PR DESCRIPTION
Automated update by update.py (method: git-commits).