### PR TITLE
nextpnr-unstable: unstable-2023-04-05 -> unstable-2023-04-14

### DIFF
--- a/nextpnr-unstable/default.nix
+++ b/nextpnr-unstable/default.nix
@@ -1,13 +1,13 @@
 { nextpnrWithGui, callPackage, fetchFromGitHub }:
 
 nextpnrWithGui.overrideAttrs (final: prev: {
-  version = "unstable-2023-04-05";
+  version = "unstable-2023-04-14";
 
   src = fetchFromGitHub {
     owner = "YosysHQ";
     repo = "nextpnr";
-    rev = "9bcefe46a89a1fb55ab86f2e0a3319baf1b92807";
-    hash = "sha256-gMCAYLZ61zkSSShAzbk8RVSXAF6Kfzptu7VT4Er9YZc=";
+    rev = "71192dc7a3b8dfae1f76f48412dd906bfb0783e7";
+    hash = "sha256-QzKWcajJJBjoqWRweOy9W4JZ3q5w+Bl+ixBs3NLLOZ0=";
   };
 
   passthru = (prev.passthru or { }) // { autoUpdate = "git-commits"; };


### PR DESCRIPTION
Automated update by update.py (method: git-commits).