### PR TITLE
nextpnr-unstable: unstable-2023-04-14 -> unstable-2023-04-18

### DIFF
--- a/nextpnr-unstable/default.nix
+++ b/nextpnr-unstable/default.nix
@@ -1,13 +1,13 @@
 { nextpnrWithGui, callPackage, fetchFromGitHub }:
 
 nextpnrWithGui.overrideAttrs (final: prev: {
-  version = "unstable-2023-04-14";
+  version = "unstable-2023-04-18";
 
   src = fetchFromGitHub {
     owner = "YosysHQ";
     repo = "nextpnr";
-    rev = "71192dc7a3b8dfae1f76f48412dd906bfb0783e7";
-    hash = "sha256-QzKWcajJJBjoqWRweOy9W4JZ3q5w+Bl+ixBs3NLLOZ0=";
+    rev = "051bdb12b3b695d74a829a231f3e3bf4d0a26323";
+    hash = "sha256-+U3f3LT3gC3j5MrerA6cmhAThDvLyjAVnE7YieTeWTc=";
   };
 
   passthru = (prev.passthru or { }) // { autoUpdate = "git-commits"; };


### PR DESCRIPTION
Automated update by update.py (method: git-commits).