### PR TITLE
nextpnr-unstable: unstable-2023-04-18 -> unstable-2023-05-03

### DIFF
--- a/nextpnr-unstable/default.nix
+++ b/nextpnr-unstable/default.nix
@@ -1,13 +1,13 @@
 { nextpnrWithGui, callPackage, fetchFromGitHub }:
 
 nextpnrWithGui.overrideAttrs (final: prev: {
-  version = "unstable-2023-04-18";
+  version = "unstable-2023-05-03";
 
   src = fetchFromGitHub {
     owner = "YosysHQ";
     repo = "nextpnr";
-    rev = "051bdb12b3b695d74a829a231f3e3bf4d0a26323";
-    hash = "sha256-+U3f3LT3gC3j5MrerA6cmhAThDvLyjAVnE7YieTeWTc=";
+    rev = "91771895b698804439257e85e2afda83b81f074c";
+    hash = "sha256-V4PXCKB/mpQf0rswcvDvw4VfONO0oS8toYcX08e86uM=";
   };
 
   passthru = (prev.passthru or { }) // { autoUpdate = "git-commits"; };


### PR DESCRIPTION
Automated update by update.py (method: git-commits).