### PR TITLE
nextpnr-unstable: unstable-2023-05-03 -> unstable-2023-04-20

### DIFF
--- a/nextpnr-unstable/default.nix
+++ b/nextpnr-unstable/default.nix
@@ -1,13 +1,13 @@
 { nextpnrWithGui, callPackage, fetchFromGitHub }:
 
 nextpnrWithGui.overrideAttrs (final: prev: {
-  version = "unstable-2023-05-03";
+  version = "unstable-2023-04-20";
 
   src = fetchFromGitHub {
     owner = "YosysHQ";
     repo = "nextpnr";
-    rev = "91771895b698804439257e85e2afda83b81f074c";
-    hash = "sha256-V4PXCKB/mpQf0rswcvDvw4VfONO0oS8toYcX08e86uM=";
+    rev = "57b923a6031f28f5d5a2c48d733cd86a3bcf2737";
+    hash = "sha256-dv4WR1Ux/gL57gD0f3ZWCrqhB/6ZVDgPN9PiMOxnaAw=";
   };
 
   passthru = (prev.passthru or { }) // { autoUpdate = "git-commits"; };


### PR DESCRIPTION
Automated update by update.py (method: git-commits).